### PR TITLE
chore: rename mlkem-rust-libcrux to rust-libcrux

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,7 +3,7 @@
 #
 
 repository:
-  name: mlkem-rust-libcrux
+  name: rust-libcrux
   description: portable ML-KEM implementation with some optimizations for AVX2. Full AVX2 support will be added over the coming months. The code is formally verified for panic freedom, correctness, and secret independence in F* using the hax toolchain.
   homepage: https://github.com/pq-code-package/mlkem-rust-libcrux
   default_branch: main


### PR DESCRIPTION
[//]: # (SPDX-License-Identifier: CC-BY-4.0)

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)

Part of [this chain](https://github.com/pq-code-package/tsc/pull/186)
See also [this issue](https://github.com/pq-code-package/tsc/issues/181)